### PR TITLE
- Fixed some bugs

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -11,7 +11,7 @@ var listener = function(details) {
       contentDispositionIndex = i;
     }
   }
-  
+
   if(contentDispositionIndex !== -1) {
     details.responseHeaders[contentDispositionIndex].value = 'inline';
     if(contentTypeIndex !== -1) {
@@ -25,4 +25,4 @@ var listener = function(details) {
   return {responseHeaders:details.responseHeaders};
 }
 
-chrome.webRequest.onHeadersReceived.addListener(listener, {urls: ['http://learn.canterbury.ac.nz/pluginfile.php/*']}, ['blocking', 'responseHeaders']);
+chrome.webRequest.onHeadersReceived.addListener(listener, {urls: ['http://learn.canterbury.ac.nz/pluginfile.php/*', 'https://learn.canterbury.ac.nz/pluginfile.php/*']}, ['blocking', 'responseHeaders']);

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -1,5 +1,7 @@
 (() => {
+
   let container = document.getElementById("resourceobject");
+
   if (container) {
     return window.location.replace(container.data);
   } else {
@@ -24,7 +26,7 @@
         buttons[0].click();
       }
     }
-    data.ignored_courses.forEach((title) => {
+    data.ignored_courses && data.ignored_courses.forEach((title) => {
       let node = document.querySelector('.block_course_list [title="' + title + '"]');
       if (node !== null) {
         node.parentNode.parentNode.remove();

--- a/chrome/content.js
+++ b/chrome/content.js
@@ -26,12 +26,15 @@
         buttons[0].click();
       }
     }
-    data.ignored_courses && data.ignored_courses.forEach((title) => {
-      let node = document.querySelector('.block_course_list [title="' + title + '"]');
-      if (node !== null) {
-        node.parentNode.parentNode.remove();
-      }
-    });
+    if (data.ignored_courses){
+        data.ignored_courses.forEach((title) => {
+            let node = document.querySelector('.block_course_list [title="' + title + '"]');
+            if (node !== null) {
+                node.parentNode.parentNode.remove();
+            }
+        });
+    }
+
   });
   let main = document.getElementById('region-main');
   if (main) {

--- a/chrome/manifest.json
+++ b/chrome/manifest.json
@@ -5,13 +5,14 @@
   "content_scripts": [
     {
       "matches": [
-        "http://learn.canterbury.ac.nz/*"
+        "http://learn.canterbury.ac.nz/*",
+        "https://learn.canterbury.ac.nz/*"
       ],
       "js": [
         "pranks.js",
         "content.js"
       ],
-      "run_at": "document_start"
+      "run_at": "document_end"
     },
     {
       "matches": [
@@ -27,10 +28,12 @@
     },
     {
       "matches": [
-        "http://learn.canterbury.ac.nz/*"
+        "http://learn.canterbury.ac.nz/*",
+        "https://learn.canterbury.ac.nz/*"
       ],
       "exclude_matches": [
-        "http://learn.canterbury.ac.nz/pluginfile.php/*"
+        "http://learn.canterbury.ac.nz/pluginfile.php/*",
+        "https://learn.canterbury.ac.nz/pluginfile.php/*"
       ],
       "css": [
         "content.css"

--- a/chrome/pranks.js
+++ b/chrome/pranks.js
@@ -24,8 +24,8 @@ function aprilFools() {
       add("<style>" + styles + "</style>");
     },
     () => window.open('https://www.youtube.com/watch?v=dQw4w9WgXcQ'),
-    () => add("<style>div{transform:rotate(180deg);}</style>",
-    () => add("<style>body {animation: marquee 10s linear infinite;position:absolute;width:100%;} @keyframes marquee {0% {left: 100%;} 100% {left: -100%;}}</style>",
+    () => add("<style>div{transform:rotate(180deg);}</style>"),
+    () => add("<style>body {animation: marquee 10s linear infinite;position:absolute;width:100%;} @keyframes marquee {0% {left: 100%;} 100% {left: -100%;}}</style>"),
     () => add("<style>body {animation: marquee 0.1s linear infinite;position:absolute;width:100%;} @keyframes marquee {0% {left: -0.5%;top: 0.5%;} 50% {top: 0%;left: 0.5%;} 100% {left: 0.5%;left: 0.5%;}}</style>")
   ][Math.floor(Math.random() * 9)]();
 }


### PR DESCRIPTION
Hi Will,

They changed the way learn renders pdfs so you have to wait until the dom is completely loaded until executing the content script. I changed this and added the following: changes

- Fixed syntax error when ignored courses doesnt load correctly
- Fixed syntax error in pranks
- Updated manifest to wait for pdf to load and to allow for https support

Is there any chance you could redeploy the extension, or give me the ability to do so! 
Cheers,
Stefan